### PR TITLE
Updated navigation link to the English site.

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -18,8 +18,8 @@
   link: https://sh-akira.github.io/VirtualMotionCapture/
   new_window: false
   highlight: false
-- name: 한국어
-  link: https://sh-akira.github.io/VirtualMotionCapture-ko/
+- name: EN
+  link: https://sh-akira.github.io/VirtualMotionCapture-en/
   new_window: false
   highlight: false
 


### PR DESCRIPTION
Replaced the link to the Korean site, which only links back to the same site, with the link to the English site.  Please merge when the English site is ready.